### PR TITLE
Added caching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.1
+
+- update documentation
+- Cache the data in the global scope so that it can be shared with
+all instances of LocaleData
+
 ### v1.0.0
 
 - Initial version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-localedata",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./lib/index.js",
     "description": "Load and cache iLib locale data",
     "keywords": [

--- a/src/DataCache.js
+++ b/src/DataCache.js
@@ -97,20 +97,20 @@ class DataCache {
     static getDataCache(options) {
         if (!options || typeof(options.packageName) !== 'string') return;
 
-	    const globalScope = top();
-	
-	    if (!globalScope.ilib) {
-	        globalScope.ilib = {};
-	    }
+        const globalScope = top();
+
+        if (!globalScope.ilib) {
+            globalScope.ilib = {};
+        }
 
         if (!globalScope.ilib.dataCache) {
             globalScope.ilib.dataCache = {};
         }
-        
+
         if (!globalScope.ilib.dataCache[options.packageName]) {
             globalScope.ilib.dataCache[options.packageName] = new DataCache(options);
         }
-        
+
         return globalScope.ilib.dataCache[options.packageName];
     }
 

--- a/src/DataCache.js
+++ b/src/DataCache.js
@@ -21,6 +21,7 @@
 import log4js from '@log4js-node/log4js-api';
 
 import { getLocFiles, Path } from 'ilib-common';
+import { top } from 'ilib-env';
 
 /**
  * @private
@@ -62,8 +63,6 @@ function getLocaleSpec(locale) {
  * on another package's data is dangerous. Instead, that other package should
  * be designed to provide a stable API for the current package to get
  * any information that it may need.<p>
- *
- * @class
  */
 class DataCache {
     /**
@@ -76,7 +75,7 @@ class DataCache {
      * data is being cached.
      * </ul>
      *
-     * @class
+     * @private
      * @param {string} name the unique name for this type of locale data
      * @param {Object} options Options governing the construction of this
      * cache
@@ -93,6 +92,26 @@ class DataCache {
 
         this.count = 0;
         this.data = {};
+    }
+
+    static getDataCache(options) {
+        if (!options || typeof(options.packageName) !== 'string') return;
+
+	    const globalScope = top();
+	
+	    if (!globalScope.ilib) {
+	        globalScope.ilib = {};
+	    }
+
+        if (!globalScope.ilib.dataCache) {
+            globalScope.ilib.dataCache = {};
+        }
+        
+        if (!globalScope.ilib.dataCache[options.packageName]) {
+            globalScope.ilib.dataCache[options.packageName] = new DataCache(options);
+        }
+        
+        return globalScope.ilib.dataCache[options.packageName];
     }
 
     /**

--- a/test/testDataCache.js
+++ b/test/testDataCache.js
@@ -24,7 +24,7 @@ import DataCache from '../src/DataCache';
 module.exports.testDataCache = {
     testDataCacheConstructor: function(test) {
         test.expect(2);
-        let cache = new DataCache({packageName: "test"});
+        let cache = DataCache.getDataCache({packageName: "test"});
 
         test.equal(cache.getPackage(), "test");
         test.equal(cache.size(), 0);
@@ -32,9 +32,21 @@ module.exports.testDataCache = {
         test.done();
     },
 
+    testDataCacheConstructorIsGlobal: function(test) {
+        test.expect(1);
+        let cache1 = DataCache.getDataCache({packageName: "test"});
+
+        let cache2 = DataCache.getDataCache({packageName: "test"});
+
+        // should be the exact same instance
+        test.equal(cache1, cache2);
+
+        test.done();
+    },
+
     testDataCacheGetDataEmpty: function(test) {
         test.expect(1);
-        let cache = new DataCache({packageName: "test"});
+        let cache = DataCache.getDataCache({packageName: "test"});
 
         const data = cache.getData("basename", new Locale("en-US"));
 
@@ -46,7 +58,7 @@ module.exports.testDataCache = {
 
     testDataCacheStoreData: function(test) {
         test.expect(2);
-        let cache = new DataCache({packageName: "test"});
+        let cache = DataCache.getDataCache({packageName: "test"});
 
         cache.storeData("basename", new Locale("en-US"), { x: "string" });
 
@@ -54,242 +66,32 @@ module.exports.testDataCache = {
 
         test.ok(data);
         test.deepEqual(data, { x: "string" });
-
-        test.done();
-    },
-
-    testDataCacheStoreDataDifferentLocales: function(test) {
-        test.expect(4);
-        let cache = new DataCache({packageName: "test"});
-
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-        cache.storeData("basename", new Locale("en"), { y: "string1" });
-
-        let data = cache.getData("basename", new Locale("en-US"));
-
-        test.ok(data);
-        test.deepEqual(data, { x: "string" });
-
-        data = cache.getData("basename", new Locale("en"));
-
-        test.ok(data);
-        test.deepEqual(data, { y: "string1" });
-
-        test.done();
-    },
-
-    testDataCacheStoreDataDifferentBasenames: function(test) {
-        test.expect(4);
-        let cache = new DataCache({packageName: "test"});
-
-        cache.storeData("basename1", new Locale("en-US"), { x: "string" });
-        cache.storeData("basename2", new Locale("en-US"), { y: "string1" });
-
-        let data = cache.getData("basename1", new Locale("en-US"));
-
-        test.ok(data);
-        test.deepEqual(data, { x: "string" });
-
-        data = cache.getData("basename2", new Locale("en-US"));
-
-        test.ok(data);
-        test.deepEqual(data, { y: "string1" });
-
-        test.done();
-    },
-
-    testDataCacheStoreDataNoBasename: function(test) {
-        test.expect(3);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        cache.storeData(undefined, new Locale("en-US"), { x: "string" });
-        test.equal(cache.size(), 0);
-
-        const data = cache.getData(undefined, new Locale("en-US"));
-
-        test.equal(typeof(data), 'undefined');
-
-        test.done();
-    },
-
-    testDataCacheStoreDataNoLocaleMeansRoot: function(test) {
-        test.expect(4);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        // empty locale = root
-        cache.storeData("basename", undefined, { x: "string" });
-        test.equal(cache.size(), 1);
-
-        const data = cache.getData("basename", undefined);
-
-        test.ok(data);
-        test.deepEqual(data, { x: "string" });
-
-        test.done();
-    },
-
-    testDataCacheStoreDataNull: function(test) {
-        test.expect(2);
-        let cache = new DataCache({packageName: "test"});
-
-        cache.storeData("basename", new Locale("en-US"), null);
-
-        const data = cache.getData("basename", new Locale("en-US"));
-
-        // null = files for this locale do not exist
-        test.ok(typeof(data) != 'undefined');
-        test.deepEqual(data, null);
-
-        test.done();
-    },
-
-    testDataCacheStoreDataRightSize: function(test) {
-        test.expect(3);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-        test.equal(cache.size(), 1);
-        cache.storeData("basename", new Locale("en-CA"), { x: "string" });
-        test.equal(cache.size(), 2);
-
-        test.done();
-    },
-
-    testDataCacheStoreDataOverride: function(test) {
-        test.expect(4);
-        let cache = new DataCache({packageName: "test"});
-
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-
-        let data = cache.getData("basename", new Locale("en-US"));
-
-        test.ok(data);
-        test.deepEqual(data, { x: "string" });
-
-        cache.storeData("basename", new Locale("en-US"), { z: true });
-
-        data = cache.getData("basename", new Locale("en-US"));
-
-        test.ok(data);
-        test.deepEqual(data, { z: true });
-
-        test.done();
-    },
-
-    testDataCacheStoreDataOverrideRightSize: function(test) {
-        test.expect(3);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-
-        test.equal(cache.size(), 1);
-
-        cache.storeData("basename", new Locale("en-US"), { z: true });
-
-        // overrides do not increase the size
-        test.equal(cache.size(), 1);
-
-        test.done();
-    },
-
-    testDataCacheRemoveData: function(test) {
-        test.expect(3);
-        let cache = new DataCache({packageName: "test"});
-
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-
-        let data = cache.getData("basename", new Locale("en-US"));
-
-        test.ok(data);
-        test.deepEqual(data, { x: "string" });
-
-        cache.removeData("basename", new Locale("en-US"));
-
-        data = cache.getData("basename", new Locale("en-US"));
-
-        test.equal(typeof(data), 'undefined');
-
-        test.done();
-    },
-
-    testDataCacheRemoveDataRightSize: function(test) {
-        test.expect(3);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-
-        test.equal(cache.size(), 1);
-
-        cache.removeData("basename", new Locale("en-US"));
-
-        test.equal(cache.size(), 0);
-
-        test.done();
-    },
-
-    testDataCacheRemoveDataNoBasename: function(test) {
-        test.expect(3);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-
-        test.equal(cache.size(), 1);
-
-        cache.removeData(undefined, new Locale("en-US"));
-
-        test.equal(cache.size(), 1);
-
-        test.done();
-    },
-
-    testDataCacheRemoveDataNoLocale: function(test) {
-        test.expect(3);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        cache.storeData("basename", new Locale("en-US"), { x: "string" });
-
-        test.equal(cache.size(), 1);
-
-        cache.removeData("basename");
-
-        test.equal(cache.size(), 1);
-
-        test.done();
-    },
-
-    testDataCacheRemoveDataRootLocale: function(test) {
-        test.expect(5);
-        let cache = new DataCache({packageName: "test"});
-
-        test.equal(cache.size(), 0);
-        cache.storeData("basename", undefined, { x: "string" });
-
-        test.equal(cache.size(), 1);
-        let data = cache.getData("basename", undefined);
-
-        test.deepEqual(data, { x: 'string' });
-
-        cache.removeData("basename");
-
-        test.equal(cache.size(), 0);
-
-        data = cache.getData("basename", new Locale("en-US"));
-
-        test.equal(typeof(data), 'undefined');
 
         test.done();
     },
 
     testDataCacheClearData: function(test) {
+        test.expect(2);
+        let cache = DataCache.getDataCache({packageName: "test"});
+
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+
+        let data = cache.getData("basename", new Locale("en-US"));
+        test.ok(data);
+
+        cache.clearData();
+
+        data = cache.getData("basename", new Locale("en-US"));
+
+        test.ok(!data);
+
+        test.done();
+    },
+
+    testDataCacheClearDataMultiple: function(test) {
         test.expect(12);
-        let cache = new DataCache({packageName: "test"});
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
 
         test.equal(cache.size(), 0);
         cache.storeData("basename", new Locale("en-US"), { x: "string" });
@@ -322,7 +124,8 @@ module.exports.testDataCache = {
 
     testDataCacheClearDataRightSize: function(test) {
         test.expect(3);
-        let cache = new DataCache({packageName: "test"});
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
 
         test.equal(cache.size(), 0);
         cache.storeData("basename", new Locale("en-US"), { x: "string" });
@@ -332,6 +135,248 @@ module.exports.testDataCache = {
 
         cache.clearData();
         test.equal(cache.size(), 0);
+
+        test.done();
+    },
+
+    testDataCacheStoreDataDifferentLocales: function(test) {
+        test.expect(4);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+        cache.storeData("basename", new Locale("en"), { y: "string1" });
+
+        let data = cache.getData("basename", new Locale("en-US"));
+
+        test.ok(data);
+        test.deepEqual(data, { x: "string" });
+
+        data = cache.getData("basename", new Locale("en"));
+
+        test.ok(data);
+        test.deepEqual(data, { y: "string1" });
+
+        test.done();
+    },
+
+    testDataCacheStoreDataDifferentBasenames: function(test) {
+        test.expect(4);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        cache.storeData("basename1", new Locale("en-US"), { x: "string" });
+        cache.storeData("basename2", new Locale("en-US"), { y: "string1" });
+
+        let data = cache.getData("basename1", new Locale("en-US"));
+
+        test.ok(data);
+        test.deepEqual(data, { x: "string" });
+
+        data = cache.getData("basename2", new Locale("en-US"));
+
+        test.ok(data);
+        test.deepEqual(data, { y: "string1" });
+
+        test.done();
+    },
+
+    testDataCacheStoreDataNoBasename: function(test) {
+        test.expect(3);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        cache.storeData(undefined, new Locale("en-US"), { x: "string" });
+        test.equal(cache.size(), 0);
+
+        const data = cache.getData(undefined, new Locale("en-US"));
+
+        test.equal(typeof(data), 'undefined');
+
+        test.done();
+    },
+
+    testDataCacheStoreDataNoLocaleMeansRoot: function(test) {
+        test.expect(4);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        // empty locale = root
+        cache.storeData("basename", undefined, { x: "string" });
+        test.equal(cache.size(), 1);
+
+        const data = cache.getData("basename", undefined);
+
+        test.ok(data);
+        test.deepEqual(data, { x: "string" });
+
+        test.done();
+    },
+
+    testDataCacheStoreDataNull: function(test) {
+        test.expect(2);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        cache.storeData("basename", new Locale("en-US"), null);
+
+        const data = cache.getData("basename", new Locale("en-US"));
+
+        // null = files for this locale do not exist
+        test.ok(typeof(data) != 'undefined');
+        test.deepEqual(data, null);
+
+        test.done();
+    },
+
+    testDataCacheStoreDataRightSize: function(test) {
+        test.expect(3);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+        test.equal(cache.size(), 1);
+        cache.storeData("basename", new Locale("en-CA"), { x: "string" });
+        test.equal(cache.size(), 2);
+
+        test.done();
+    },
+
+    testDataCacheStoreDataOverride: function(test) {
+        test.expect(4);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+
+        let data = cache.getData("basename", new Locale("en-US"));
+
+        test.ok(data);
+        test.deepEqual(data, { x: "string" });
+
+        cache.storeData("basename", new Locale("en-US"), { z: true });
+
+        data = cache.getData("basename", new Locale("en-US"));
+
+        test.ok(data);
+        test.deepEqual(data, { z: true });
+
+        test.done();
+    },
+
+    testDataCacheStoreDataOverrideRightSize: function(test) {
+        test.expect(3);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+
+        test.equal(cache.size(), 1);
+
+        cache.storeData("basename", new Locale("en-US"), { z: true });
+
+        // overrides do not increase the size
+        test.equal(cache.size(), 1);
+
+        test.done();
+    },
+
+    testDataCacheRemoveData: function(test) {
+        test.expect(3);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+
+        let data = cache.getData("basename", new Locale("en-US"));
+
+        test.ok(data);
+        test.deepEqual(data, { x: "string" });
+
+        cache.removeData("basename", new Locale("en-US"));
+
+        data = cache.getData("basename", new Locale("en-US"));
+
+        test.equal(typeof(data), 'undefined');
+
+        test.done();
+    },
+
+    testDataCacheRemoveDataRightSize: function(test) {
+        test.expect(3);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+
+        test.equal(cache.size(), 1);
+
+        cache.removeData("basename", new Locale("en-US"));
+
+        test.equal(cache.size(), 0);
+
+        test.done();
+    },
+
+    testDataCacheRemoveDataNoBasename: function(test) {
+        test.expect(3);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+
+        test.equal(cache.size(), 1);
+
+        cache.removeData(undefined, new Locale("en-US"));
+
+        test.equal(cache.size(), 1);
+
+        test.done();
+    },
+
+    testDataCacheRemoveDataNoLocale: function(test) {
+        test.expect(3);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        cache.storeData("basename", new Locale("en-US"), { x: "string" });
+
+        test.equal(cache.size(), 1);
+
+        cache.removeData("basename");
+
+        test.equal(cache.size(), 1);
+
+        test.done();
+    },
+
+    testDataCacheRemoveDataRootLocale: function(test) {
+        test.expect(5);
+        let cache = DataCache.getDataCache({packageName: "test"});
+        cache.clearData();
+
+        test.equal(cache.size(), 0);
+        cache.storeData("basename", undefined, { x: "string" });
+
+        test.equal(cache.size(), 1);
+        let data = cache.getData("basename", undefined);
+
+        test.deepEqual(data, { x: 'string' });
+
+        cache.removeData("basename");
+
+        test.equal(cache.size(), 0);
+
+        data = cache.getData("basename", new Locale("en-US"));
+
+        test.equal(typeof(data), 'undefined');
 
         test.done();
     }


### PR DESCRIPTION
Review #1 first and then I can rebase this on that one so that it is smaller and easier to review.

- add support for caching previously loaded data
- add support for populating the cache with static data via the `cacheData` static method, clear it again with the `clearCache` static method, and checking to see if the data is already loaded with the `checkCache` method
- data can be added to the cache by loading it from files (sync or async) or by the `cacheData` method. The `ensureLocale` method is not implemented yet. (Yet another PR to come.)