### PR TITLE
Fix a problem loading data from the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,21 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.3.4
+
+- fixed a bug in data caching when the cache is cleared
+- fixed a problem where sync loading is requested but the loader doesn't
+  support sync loading. In this case, if the data is not in the cache, it
+  now throws an exception. If the data is in the cache, it now returns it
+  properly.
+
+### v1.3.3
 ### v1.3.2
 
 - This module is now a hybrid ESM/CommonJS package that works under node
   or webpack
+- accidentally bumped the version to v1.3.3 before publishing the changes for
+  v1.3.2
 
 ### v1.3.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-localedata",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
         "ilib-env": "^1.3.2",
         "ilib-loader": "^1.3.2",
         "ilib-locale": "^1.2.2",
+        "ilib-localematcher": "^1.2.2",
         "json5": "^2.2.1"
     }
 }

--- a/src/DataCache.js
+++ b/src/DataCache.js
@@ -95,13 +95,8 @@ class DataCache {
      * once.
      */
     static clearDataCache() {
-        const globalScope = top();
-
-        if (!globalScope.ilib) {
-            globalScope.ilib = {};
-        }
-
-        globalScope.ilib.dataCache = new DataCache();
+        const cache = DataCache.getDataCache();
+        cache.clearData();
     }
 
     /**

--- a/src/LocaleData.js
+++ b/src/LocaleData.js
@@ -25,6 +25,7 @@ import { getPlatform, getLocale, top } from 'ilib-env';
 import LoaderFactory from 'ilib-loader';
 import { Utils, JSUtils, Path } from 'ilib-common';
 import Locale from 'ilib-locale';
+import LocaleMatcher from 'ilib-localematcher';
 
 import DataCache from './DataCache.js';
 
@@ -326,11 +327,21 @@ class LocaleData {
         } = params || {};
 
         // first check if it's in the cache
-        // const locales = Utils.getSublocales(locale).map((sublocale) => { locale: sublocale });
         // normalize the spec
         let loc = new Locale(locale);
         if (locale && locale !== "root" && !loc.getLanguage()) {
             loc = new Locale("und", loc.getRegion(), loc.getVariant(), loc.getScript());
+        }
+
+        if (sync && !this.loader.supportsSync() && !LocaleData.checkCache(loc.getSpec(), basename)) {
+            const lm = new LocaleMatcher({
+                locale: loc.getSpec(),
+                sync: true
+            });
+            loc = new Locale(lm.getLikelyLocale());
+            if (!LocaleData.checkCache(loc.getSpec(), basename)) {
+                throw "Locale data not available";
+            }
         }
 
         // then check how to load it

--- a/src/LocaleData.js
+++ b/src/LocaleData.js
@@ -340,7 +340,8 @@ class LocaleData {
             });
             loc = new Locale(lm.getLikelyLocale());
             if (!LocaleData.checkCache(loc.getSpec(), basename)) {
-                throw "Locale data not available";
+                throw "Synchronous load was requested with a loader that does not support synchronous operation" +
+                    " and the requested locale data was not already available in the cache.";
             }
         }
 

--- a/test/testLocaleDataSync.js
+++ b/test/testLocaleDataSync.js
@@ -1,0 +1,127 @@
+/*
+ * testLocaleDataSync.js - test the locale data class synchronously
+ * on a browser
+ *
+ * Copyright © 2022 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { setPlatform, getPlatform } from 'ilib-env';
+import { registerLoader } from 'ilib-loader';
+
+import LocaleData from '../src/LocaleData.js';
+
+export const testLocaleDataSync = {
+    testLocaleDataConstructorWebLoaderDoesntSupportSync: function(test) {
+        test.expect(1);
+
+        const locData = new LocaleData({
+            path: "./test/files3",
+            sync: true
+        });
+        test.ok(!locData.isSync());
+
+        test.done();
+    },
+
+    testLocaleDataDoesntSupportSyncTestLoad: function(test) {
+        test.expect(2);
+
+        const locData = new LocaleData({
+            path: "./test/files3",
+            sync: true
+        });
+        test.ok(!locData.isSync());
+
+        // should use the default synchronicity, which is async
+        const actual = locData.loadData({
+            basename: "info",
+            locale: "root"
+        });
+
+        test.ok(actual instanceof Promise);
+
+        test.done();
+    },
+
+    testLocaleDataNodeSyncRoot: function(test) {
+        test.expect(3);
+
+        const locData = new LocaleData({
+            path: "./test/files3"
+        });
+
+        test.ok(locData);
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+        LocaleData.addGlobalRoot("./test/files3");
+
+        test.ok(!LocaleData.checkCache("de-DE", "info"));
+
+        // we request sync loading but the loader does
+        // not support it and the data is not already
+        // previously loaded, so it should throw an
+        // exception because the data cannot be loaded
+        test.throws(() => {
+            const actual = locData.loadData({
+                basename: "info",
+                locale: "de-DE",
+                sync: true
+            });
+        });
+
+        test.done();
+    },
+
+    testLocaleDataNodeSyncRootPreviouslyLoaded: function(test) {
+        test.expect(6);
+
+        const locData = new LocaleData({
+            path: "./test/files3"
+        });
+
+        test.ok(locData);
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+        LocaleData.addGlobalRoot("./test/files3");
+
+        LocaleData.ensureLocale("de-DE").then(() => {
+            test.ok(LocaleData.checkCache("de-DE", "info"));
+
+            // we request sync loading but the loader does
+            // not support it. But, the data is already
+            // previously loaded, so it should succeed based
+            // on the cached data alone
+            const actual = locData.loadData({
+                basename: "info",
+                locale: "de-DE",
+                sync: true
+            });
+            test.ok(!!actual);
+            test.equal(typeof(actual), "object");
+            test.ok(!(actual instanceof Promise));
+
+            const expected = {
+                "a": "b de",
+                "c": "d de"
+            };
+            test.deepEqual(actual, expected);
+
+            test.done();
+        });
+    },
+};

--- a/test/testSuiteWeb.js
+++ b/test/testSuiteWeb.js
@@ -20,9 +20,11 @@
 import { testDataCache } from './testDataCache.js';
 import { testGetLocaleData } from './testGetLocaleData.js';
 import { testLocaleData } from './testLocaleData.js';
+import { testLocaleDataSync } from './testLocaleDataSync.js';
 
 export const tests = [
     testDataCache,
     testGetLocaleData,
-    testLocaleData
+    testLocaleData,
+    testLocaleDataSync
 ];


### PR DESCRIPTION
- if the loader does not support sync loading and sync loading is
    requested, then loadData() should check the cache. If the data is
    in the cache already (by previous loads or by ensureLocale) then
    the data can be returned synchronously anyways.
- that way, you can do ensureLocale() at the top of your program
    and always load locale data synchronously after that
- this mechanism was somewhat broken before as we didn't check
    the cache and throw an exception if the data was not there
- also fixed DataCache.clearCache() so that it resets the cache
    instead of creating a whole new one. The problem was if you have
    an existing pointer to the old cache through a LocaleData object,
    and then call LocaleData.clearCache() you get a whole new cache
    object, but the LocaleData instance did not. It is supposed to be
    a singleton. There should never be 2 instances of it!
