### PR TITLE
Load assembled locale data file first if it is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,18 @@ limitations under the License.
 
 ## Release Notes
 
-### v1.3.4
+### v1.4.0
 
 - fixed a bug in data caching when the cache is cleared
 - fixed a problem where sync loading is requested but the loader doesn't
   support sync loading. In this case, if the data is not in the cache, it
   now throws an exception. If the data is in the cache, it now returns it
   properly.
+- in async mode only, add the ability to load the assembled locale data
+  files automatically before any individual files in order to save time.
+  If there is an assembled locale data file, it loads one file and then
+  returns the data, instead of loading many files and merging the results
+  before returning the data.
 
 ### v1.3.3
 ### v1.3.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-localedata",
-    "version": "1.3.4",
+    "version": "1.4.0",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/test/testLocaleData.js
+++ b/test/testLocaleData.js
@@ -268,7 +268,9 @@ export const testLocaleData = {
         setPlatform();
         test.expect(1);
 
-        // should have the path of caller in it only
+        LocaleData.clearGlobalRoots();
+
+        // should be empty now
         test.deepEqual(LocaleData.getGlobalRoots(), []);
 
         test.done();


### PR DESCRIPTION
In async mode only, add the ability to load the assembled locale data files automatically before any individual files in order to save time. If there is an assembled locale data file, it loads one file and then returns the data, instead of loading many files and merging the results before returning the data.